### PR TITLE
Support for $args in get_avatar() in WP 4.2+

### DIFF
--- a/edd-purchase-gravatars.php
+++ b/edd-purchase-gravatars.php
@@ -293,7 +293,7 @@ if ( ! class_exists( 'EDD_Purchase_Gravatars' ) ) {
 
 					// show gravatar
                                         global $wp_version;
-                                        
+
                                         if ( version_compare( $wp_version, '4.2', '>=' ) ) {
                                             $data = array(
                                                 'email'         => $email,
@@ -301,9 +301,9 @@ if ( ! class_exists( 'EDD_Purchase_Gravatars' ) ) {
                                                 'default_image' => $default_image,
                                                 'name'          => $name
                                             );
-                                            
+
                                             $args = apply_filters( 'edd_pg_gravatar_args', array(), $data );
-                                            
+
                                             echo get_avatar( $email, $size, $default_image, $name, $args );
                                         } else {
                                             echo get_avatar( $email, $size, $default_image, $name );
@@ -433,7 +433,7 @@ if ( ! class_exists( 'EDD_Purchase_Gravatars' ) ) {
 				// Use the previously noted array key as an array key again and next your settings
 				$edd_pg_settings = array( 'purchase_gravatars' => $edd_pg_settings );
 			}
-			
+
 			return array_merge( $sections, $edd_pg_settings );
 		}
 

--- a/edd-purchase-gravatars.php
+++ b/edd-purchase-gravatars.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'EDD_Purchase_Gravatars' ) ) {
 			add_filter( 'edd_settings_extensions', array( $this, 'settings' ) );
 			add_filter( 'edd_settings_sections_extensions', array( $this, 'register_section' ) );
 
-			do_action( 'edd_pg_setup_actions' );
+                        do_action( 'edd_pg_setup_actions' );
 		}
 
 		/**
@@ -292,7 +292,22 @@ if ( ! class_exists( 'EDD_Purchase_Gravatars' ) ) {
 					echo '<span class="edd-purchase-gravatar">';
 
 					// show gravatar
-					echo get_avatar( $email, $size, $default_image, $name );
+                                        global $wp_version;
+                                        
+                                        if ( version_compare( $wp_version, '4.2', '>=' ) ) {
+                                            $data = array(
+                                                'email'         => $email,
+                                                'size'          => $size,
+                                                'default_image' => $default_image,
+                                                'name'          => $name
+                                            );
+                                            
+                                            $args = apply_filters( 'edd_pg_gravatar_args', array(), $data );
+                                            
+                                            echo get_avatar( $email, $size, $default_image, $name, $args );
+                                        } else {
+                                            echo get_avatar( $email, $size, $default_image, $name );
+                                        }
 
 					do_action( 'edd_purchase_gravatars' );
 


### PR DESCRIPTION
Adds support for get_avatar $args parameter, introduced in WP 4.2...without breaking backward compatibility.  Set the args via filter, 'edd_pg_gravatar_args'.

This allows neat things like appending the class and adding attributes to the img html.  

See:  https://codex.wordpress.org/Function_Reference/get_avatar